### PR TITLE
Revision of Plugin to allow more flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-openmediavault-letsencrypt
+openmediavault-acme
 ==========================
 
 Using the power of Let's Encrypt, generate valid SSL certificates for your OpenMediaVault.
 Your SSL certificate will be recognized by the majority of browsers.
+
+This fork of the famous letsencrpyt-plugin uses the wonderful acme.sh implementation instead of certbot. This way, you can use the DNS-APIs provided for the ACME-Challenge and create wildcard certificates for instance.
+
+More Information: [ACME Homepage](https://acme.sh/)
 
 The key principles behind Let’s Encrypt are:
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 openmediavault-acme (3.4.6) stable; urgency=low
 
-  * Add DNS Providers Duckdns, DDNSS and DeSec
+  * Add DNS Providers Duckdns, DDNSS and DeSec and change install path's to /opt/acme
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 28 Dec 2017 15:29:57 -0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-acme (3.4.7) stable; urgency=low
+
+  * Make DNS-API completly flexible by allowing individual settings
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 28 Dec 2017 15:29:57 -0600
+
 openmediavault-acme (3.4.6) stable; urgency=low
 
   * Add DNS Providers Duckdns, DDNSS and DeSec and change install path's to /opt/acme

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-acme (3.4.9) stable; urgency=low
+
+  * Fix Cronjob
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 28 Dec 2017 15:29:57 -0600
+ 
 openmediavault-acme (3.4.8) stable; urgency=low
 
   * Cleaning up the interface

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-acme (3.4.6) stable; urgency=low
+
+  * Add DNS Providers Duckdns, DDNSS and DeSec
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 28 Dec 2017 15:29:57 -0600
+
 openmediavault-acme (3.4.5) stable; urgency=low
 
   * Add date to cert description field

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-acme (3.4.8) stable; urgency=low
+
+  * Cleaning up the interface
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 28 Dec 2017 15:29:57 -0600
+
 openmediavault-acme (3.4.7) stable; urgency=low
 
   * Make DNS-API completly flexible by allowing individual settings

--- a/debian/postinst
+++ b/debian/postinst
@@ -19,7 +19,12 @@ case "$1" in
             omv-confdbadm migrate "conf.service.acme" "${2}"
         fi
         echo "Install acme.sh"
-        curl "https://get.acme.sh" | sh
+        cd /tmp
+        git clone https://github.com/Neilpang/acme.sh.git
+        cd acme.sh
+        ./acme.sh --install --home /opt/acme --config-home /opt/acme
+        cd ..
+        rm -rf acme.sh
         crontab -l | awk '!/acme\.sh/' | crontab -
     ;;
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -11,8 +11,8 @@ case "$1" in
     purge)
         omv_config_delete "/config/services/acme"
 
-        if [ -d "/root/.acme.sh" ]; then
-            rm -rf "/root/.acme.sh"
+        if [ -d "/opt/acme" ]; then
+            rm -rf "/opt/acme"
         fi
 
         if [ -f "${LETSENCRYPT_CRON}" ]; then

--- a/debian/postrm
+++ b/debian/postrm
@@ -12,6 +12,7 @@ case "$1" in
         omv_config_delete "/config/services/acme"
 
         if [ -d "/opt/acme" ]; then
+            /opt/acme/acme.sh --uninstall
             rm -rf "/opt/acme"
         fi
 

--- a/usr/share/openmediavault/datamodels/conf.service.acme.domain.json
+++ b/usr/share/openmediavault/datamodels/conf.service.acme.domain.json
@@ -23,6 +23,10 @@
 		"webroot": {
 			"type": "string",
 			"default": ""
+		},
+		"dnsapi": {
+			"type": "string",
+			"default": ""
 		}
 	}
 }

--- a/usr/share/openmediavault/datamodels/conf.service.acme.json
+++ b/usr/share/openmediavault/datamodels/conf.service.acme.json
@@ -73,6 +73,10 @@
 								"description": "The validation type of your internet facing",
 								"type": "string"
 							},
+							"dnsapi": {
+								"description": "The DNS-API to user",
+								"type": "string"
+							},					
 							"webroot": {
 								"description": "The root directory of the files served by your internet facing webserver",
 								"type": "string",

--- a/usr/share/openmediavault/datamodels/rpc.acme.json
+++ b/usr/share/openmediavault/datamodels/rpc.acme.json
@@ -54,10 +54,14 @@
 			},
 			"validation": {
 				"type": "string",
-				"enum": ["webroot", "dns_cf", "dns_he", "dns_duckdns", "dns_ddnss", "dns_desec", "dns_gandi_livedns"],
+				"enum": ["webroot", "dnsapi"],
 				"required": true
 			},
 			"webroot": {
+				"type": "string",
+				"required": true
+			},
+			"dnsapi": {
 				"type": "string",
 				"required": true
 			}

--- a/usr/share/openmediavault/datamodels/rpc.acme.json
+++ b/usr/share/openmediavault/datamodels/rpc.acme.json
@@ -54,7 +54,7 @@
 			},
 			"validation": {
 				"type": "string",
-				"enum": ["webroot", "dns_cf", "dns_he", "dns_gandi_livedns"],
+				"enum": ["webroot", "dns_cf", "dns_he", "dns_duckdns", "dns_ddnss", "dns_desec", "dns_gandi_livedns"],
 				"required": true
 			},
 			"webroot": {

--- a/usr/share/openmediavault/engined/inc/90acme.inc
+++ b/usr/share/openmediavault/engined/inc/90acme.inc
@@ -7,7 +7,7 @@ require_once("openmediavault/functions.inc");
 // 2016-01-17 19:34:29,266:DEBUG:acme.cli:Picked account: <Account(eb49da97b040939e9439a6a1c123294c)>
 \OMV\System\LogFileSpec::registerSpecification("acme", [
     "filename" => "acme",
-    "filepath" => "/root/.acme.sh/acme.sh.log",
+    "filepath" => "/opt/acme/acme.sh.log",
     "regex"    => "/^\[([^\[\]]+)\] ([[:print:]]+)$/",
     "columns"  => [
         "ts" => [

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -196,6 +196,11 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                     'operator' => 'stringEquals',
                     'arg0' => 'webroot',
                     'arg1' => $object->get('webroot')
+                ],
+                'arg2' => [
+                    'operator' => 'stringEquals',
+                    'arg0' => 'dnsapi',
+                    'arg1' => $object->get('dnsapi')
                 ]
             ]);
         }

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -184,7 +184,8 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
         $isNew = $object->isNew();
         $db = \OMV\Config\Database::getInstance();
         if (TRUE === $isNew) {
-            // Check uniqueness - web root
+          if ($domainv->get('validation') == 'webroot') {  
+            // Check uniqueness - web root (only if webroot is used)
             $db->assertIsUniqueByFilter($object, [
                 'operator' => 'and',
                 'arg0' => [
@@ -196,15 +197,11 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                     'operator' => 'stringEquals',
                     'arg0' => 'webroot',
                     'arg1' => $object->get('webroot')
-                ],
-                'arg2' => [
-                    'operator' => 'stringEquals',
-                    'arg0' => 'dnsapi',
-                    'arg1' => $object->get('dnsapi')
                 ]
             ]);
+          }       
         }
-        $db->set($object);
+        db->set($object);
         // Return the configuration object.
         return $object->getAssoc();
     }

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -184,8 +184,8 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
         $isNew = $object->isNew();
         $db = \OMV\Config\Database::getInstance();
         if (TRUE === $isNew) {
-          if ($domainv->get('validation') == 'webroot') {  
-            // Check uniqueness - web root (only if webroot is used)
+          if ($object->get('validation') == 'webroot') {  
+            // Check uniqueness - web root
             $db->assertIsUniqueByFilter($object, [
                 'operator' => 'and',
                 'arg0' => [
@@ -199,7 +199,7 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                     'arg1' => $object->get('webroot')
                 ]
             ]);
-          }       
+          }
         }
         $db->set($object);
         // Return the configuration object.

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -276,11 +276,11 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                             );
                         }
                         foreach ($domains2 as $domain) {
-                            $cmdArgs[] = sprintf('-d %s', escapeshellarg(trim($domain)));
+                            $cmdArgs[] = sprintf('-d %s', trim($domain));
                         }
                     }
                     if (!empty($object->get('extraoptions'))) {
-                        $cmdArgs[] = escapeshellarg($object->get('extraoptions'));
+                        $cmdArgs[] = $object->get('extraoptions');
                     }
                 }
                 $cmdArgs[] = '--log /opt/acme/acme.sh.log';

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -270,7 +270,7 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                             );
                         } else {
                             $cmdArgs[] = sprintf('--dns %s',
-                                $domainv->get('validation')
+                                $domainv->get('dnsapi')
                             );
                         }
                         foreach ($domains2 as $domain) {

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -201,7 +201,7 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
             ]);
           }       
         }
-        db->set($object);
+        $db->set($object);
         // Return the configuration object.
         return $object->getAssoc();
     }

--- a/usr/share/openmediavault/engined/rpc/acme.inc
+++ b/usr/share/openmediavault/engined/rpc/acme.inc
@@ -281,9 +281,9 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                         $cmdArgs[] = escapeshellarg($object->get('extraoptions'));
                     }
                 }
-                $cmdArgs[] = '--log /root/.acme.sh/acme.sh.log';
-                $cmdArgs[] = '--home /root/.acme.sh';
-                $cmd = new \OMV\System\Process('/root/.acme.sh/acme.sh', $cmdArgs);
+                $cmdArgs[] = '--log /opt/acme/acme.sh.log';
+                $cmdArgs[] = '--home /opt/acme';
+                $cmd = new \OMV\System\Process('/opt/acme/acme.sh', $cmdArgs);
                 $cmd->setRedirect2to1(true);
                 // Enviroments
                 $cmd->setEnv('ACCOUNT_EMAIL', $object->get('email'));
@@ -301,7 +301,7 @@ class OMVRpcServiceACME extends \OMV\Rpc\ServiceAbstract
                 // Without update cert in testing mode
                 if (!$object->get('test_cert')) {
                     // Replace cert if not testing
-                    $liveDir = '/root/.acme.sh';
+                    $liveDir = '/opt/acme';
                     $keyFile = sprintf('%s/%s/%s.key', $liveDir, $certName, $certName);
                     $crtFile = sprintf('%s/%s/fullchain.cer', $liveDir, $certName);
                     if (file_exists($keyFile) && file_exists($crtFile)) {

--- a/usr/share/openmediavault/locale/openmediavault-acme.pot
+++ b/usr/share/openmediavault/locale/openmediavault-acme.pot
@@ -134,5 +134,14 @@ msgstr ""
 msgid "Hurricane Electric DNS"
 msgstr ""
 
+msgid "Duckdns DNS"
+msgstr ""
+
+msgid "DDNSS DNS"
+msgstr ""
+
+msgid "Desec DNS"
+msgstr ""
+
 msgid "Gandi LiveDNS"
 msgstr ""

--- a/usr/share/openmediavault/locale/zh_TW/openmediavault-acme.po
+++ b/usr/share/openmediavault/locale/zh_TW/openmediavault-acme.po
@@ -146,5 +146,14 @@ msgstr ""
 msgid "Hurricane Electric DNS"
 msgstr ""
 
+msgid "Duckdns DNS"
+msgstr ""
+
+msgid "DDNSS DNS"
+msgstr ""
+
+msgid "Desec DNS"
+msgstr ""
+
 msgid "Gandi LiveDNS"
 msgstr ""

--- a/usr/share/openmediavault/mkconf/acme
+++ b/usr/share/openmediavault/mkconf/acme
@@ -35,7 +35,9 @@ fi
 # Generate cron file
 cat <<EOF > ${ACME_CRON}
 # this file was automatically generated
-@monthly root omv-rpc "ACME" "generateCertificate" "{\"command\":\"renew\"}" >/dev/null 2>&1
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+@weekly root omv-rpc "ACME" "generateCertificate" "{\"command\":\"renew\"}" >/dev/null 2>&1
 EOF
 chmod 644 ${ACME_CRON}
 

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
@@ -121,7 +121,7 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
             hidden: true,
             plugins: [{
                 ptype: 'fieldinfo',
-                text: _('Provide the Name of the DNS-API to use for acme.sh (for example dns_cf). See the full list in the acme.sh wiki.')
+                text: _('Provide the Name of the DNS-API to use for acme.sh (for example dns_cf). All supported APIs can be found in the acme.sh Wiki')
             }]
         }];
     }

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
@@ -67,7 +67,7 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
             allowBlank: false,
             plugins: [{
                 ptype: 'fieldinfo',
-                text: _('Domains the certificate will be generated for and must point to this server, e.g yourdomain.tld, sub.afraid.org.  Wildcard (*) domains are not supported.  Separate multiple (sub)domains with a comma (,)')
+                text: _('Domains the certificate will be generated for and must point to this server, e.g yourdomain.tld, sub.afraid.org.  Wildcard (*) domains are supported if using DNS-Validation.  Separate multiple (sub)domains with a comma (,)')
             }]
         },{
             xtype: 'combo',

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
@@ -53,6 +53,17 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
                 '!allowBlank',
                 '!readOnly'
             ]
+        },{
+            name: ['dnsapi'],
+            conditions: [{
+                name: 'validation',
+                value: 'dnsapi'
+            }],
+            properties: [
+                'show',
+                '!allowBlank',
+                '!readOnly'
+            ]
         }]
     }],
 

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
@@ -80,6 +80,9 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
                     [ 'webroot', _('Web root') ],
                     [ 'dns_cf', _('CloudFlare DNS') ],
                     [ 'dns_he', _('Hurricane Electric DNS') ],
+                    [ 'dns_duckdns', _('Duckdns DNS') ],
+                    [ 'dns_ddnss', _('DDNSS DNS') ],
+                    [ 'dns_desec', _('Desec DNS') ],
                     [ 'dns_gandi_livedns', _('Gandi LiveDNS') ]
                 ]
             }),
@@ -140,6 +143,9 @@ Ext.define('OMV.module.admin.service.acme.Domains', {
             'webroot': _('Web root'),
             'dns_cf': _('CloudFlare DNS'),
             'dns_he': _('Hurricane Electric DNS'),
+            'dns_duckdns': _('Duckdns DNS'),
+            'dns_ddnss': _('DDNSS DNS'),
+            'dns_desec': _('Desec DNS'),
             'dns_gandi_livedns': _('Gandi LiveDNS')
         }
     },{

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
@@ -78,12 +78,7 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
                 fields: [ 'value', 'text' ],
                 data: [
                     [ 'webroot', _('Web root') ],
-                    [ 'dns_cf', _('CloudFlare DNS') ],
-                    [ 'dns_he', _('Hurricane Electric DNS') ],
-                    [ 'dns_duckdns', _('Duckdns DNS') ],
-                    [ 'dns_ddnss', _('DDNSS DNS') ],
-                    [ 'dns_desec', _('Desec DNS') ],
-                    [ 'dns_gandi_livedns', _('Gandi LiveDNS') ]
+                    [ 'dnsapi', _('DNS API') ]
                 ]
             }),
             displayField: 'text',
@@ -93,7 +88,7 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
             value: 'webroot',
             plugins: [{
                 ptype: 'fieldinfo',
-                text: _('The validation type of your internet facing.')
+                text: _('Choose your validation type.')
             }]
         },{
             xtype: 'textfield',
@@ -105,6 +100,17 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
             plugins: [{
                 ptype: 'fieldinfo',
                 text: _('The root directory of the files served by your internet facing webserver.')
+            }]
+        },{
+            xtype: 'textfield',
+            name: 'dnsapi',
+            fieldLabel: _('DNS API'),
+            allowBlank: true,
+            readOnly: true,
+            hidden: true,
+            plugins: [{
+                ptype: 'fieldinfo',
+                text: _('Provide the Name of the DNS-API to use for acme.sh.')
             }]
         }];
     }
@@ -141,12 +147,7 @@ Ext.define('OMV.module.admin.service.acme.Domains', {
         flex: 1,
         mapItems: {
             'webroot': _('Web root'),
-            'dns_cf': _('CloudFlare DNS'),
-            'dns_he': _('Hurricane Electric DNS'),
-            'dns_duckdns': _('Duckdns DNS'),
-            'dns_ddnss': _('DDNSS DNS'),
-            'dns_desec': _('Desec DNS'),
-            'dns_gandi_livedns': _('Gandi LiveDNS')
+            'dnsapi': _('DNS API')  
         }
     },{
         xtype: 'textcolumn',
@@ -154,6 +155,13 @@ Ext.define('OMV.module.admin.service.acme.Domains', {
         sortable: true,
         dataIndex: 'webroot',
         stateId: 'webroot',
+        flex: 1
+    },{
+        xtype: 'textcolumn',
+        text: _('DNS API'),
+        sortable: true,
+        dataIndex: 'dnsapi',
+        stateId: 'dnsapi',
         flex: 1
     }],
 
@@ -168,6 +176,7 @@ Ext.define('OMV.module.admin.service.acme.Domains', {
                         { name: 'uuid', type: 'string' },
                         { name: 'validation', type: 'string' },
                         { name: 'webroot', type: 'string' },
+                        { name: 'dnsapi', type: 'string' },
                         { name: 'domain', type: 'string' }
                     ]
                 }),

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Domain.js
@@ -78,7 +78,7 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
             allowBlank: false,
             plugins: [{
                 ptype: 'fieldinfo',
-                text: _('Domains the certificate will be generated for and must point to this server, e.g yourdomain.tld, sub.afraid.org.  Wildcard (*) domains are supported if using DNS-Validation.  Separate multiple (sub)domains with a comma (,)')
+                text: _('Domains the certificate will be generated for and must point to this server if using webroot-method. Wildcard (*) domains are supported if using DNS-API. Separate multiple (sub)domains with a comma (,)')
             }]
         },{
             xtype: 'combo',
@@ -121,7 +121,7 @@ Ext.define('OMV.module.admin.service.acme.Domain', {
             hidden: true,
             plugins: [{
                 ptype: 'fieldinfo',
-                text: _('Provide the Name of the DNS-API to use for acme.sh.')
+                text: _('Provide the Name of the DNS-API to use for acme.sh (for example dns_cf). See the full list in the acme.sh wiki.')
             }]
         }];
     }

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Enviroment.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Enviroment.js
@@ -71,7 +71,7 @@ Ext.define('OMV.module.admin.service.acme.Env', {
             items: [{
                 border: false,
                 html: _('DNS API validation enviroment, see: ' +
-                '<a target="_blank" href="https://github.com/Neilpang/acme.sh/tree/master/dnsapi">https://github.com/Neilpang/acme.sh/tree/master/dnsapi</a>' +
+                '<a target="_blank" href="https://github.com/Neilpang/acme.sh/wiki/dnsapi">https://github.com/Neilpang/acme.sh/wiki/dnsapi</a>' +
                 '<br>e.g.<br><code>CF_Key => sdfsdfsdfljlbjkljlkjsdfoiwje</code>')
             }]
         }];

--- a/var/www/openmediavault/js/omv/module/admin/service/acme/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/acme/Settings.js
@@ -100,10 +100,10 @@ Ext.define('OMV.module.admin.service.acme.Settings', {
             items: [{
                 border: false,
                 html: '<ul>' +
-                    '<li>Plugin uses the <a href="https://letsencrypt.readthedocs.org/en/latest/using.html#webroot">webroot installation</a> method provided by Let\'s Encrypt.</li>' +
+                    '<li>Plugin uses either the <b>webroot installation</b> or the <b>DNS-API</b> method provided by the <a href="https://github.com/Neilpang/acme.sh/wiki/How-to-issue-a-cert">acme.sh client</a> for Let\'s Encrypt.</li>' +
                     '<li>OMV configuration needs to be applied after generating certificate due to the plugin adding entries to certificates.</li>' +
-                    '<li>If you generate your first certificate with the test flag enabled your certificate will have an invalid root cert from Happy Hacker.  You will need to delete your /etc/letsencrypt folder and start over.</li>' +
-                    '<li>Port <b>80</b> must be open for Let\'s Encrypt to verify your domain.</li>' +
+                    '<li>If you generate your first certificate with the test flag enabled your certificate will have an invalid root cert from Happy Hacker.  You will need to delete your certificates in the /opt/acme folder and start over.</li>' +
+                    '<li>Port <b>80</b> must be open for Let\'s Encrypt to verify your domain in webroot mode</li>' +
                     '</ul>'
             }]
         }];


### PR DESCRIPTION
Thank you very much for your great plugin! I am so grateful that you created this fork for acme.sh, since I needed wildcard-dns with dns-challenge mode.

I took the time and revised a few things to make it work for me:
1. I changed the install path to /opt/acme (to not store a permanent program in /root, even though this is acme's default)
2. I decided to change the dns_api parameter to a textbox instead of a choicelist, so one can use any API that resides in /opt/acme/dnsapie
3. Corrected a few bugs (making the extra-options work, cleaning up some interface inconsistencies).

Thanks again for your great work. Are you planning in making an official plugin for omv from your fork? I think others might be interrested as well...